### PR TITLE
parseGps bug fix method

### DIFF
--- a/MTU_STM32/Core/Src/MTU/GPS_parsing.c
+++ b/MTU_STM32/Core/Src/MTU/GPS_parsing.c
@@ -44,6 +44,9 @@ void parseGPS(uint8_t* buf, uint16_t size) {
 			} else if(counter > 18) { // Data complete
 				counting = false;
 			}
+			else {
+				counter++;
+			}
 		}
 	}
 }


### PR DESCRIPTION
before the parsing could get stuck since there were cases that the count would never increase, fixed this by adding an else statement to increase the count by default